### PR TITLE
ci: calculate coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,19 @@
 {
   "presets": [
     [
-      "@babel/preset-env"
+      "@babel/preset-env",
+      {
+        targets: {
+          browsers: ['node 10'],
+          node: true,
+        }
+      }
     ]
   ],
   "plugins": [
+    [
+      "@babel/plugin-transform-runtime",
+    ],
     [
       "@babel/plugin-proposal-class-properties"
     ]

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
-examples/
-src/
-website/
+.idea
+/coverage
+/examples
+/src
+/website
+/scripts/release.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/with-react-native/.npmrc
+++ b/examples/with-react-native/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/with-react-native/babel.config.js
+++ b/examples/with-react-native/babel.config.js
@@ -1,3 +1,15 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  env: {
+    test: {
+      plugins: [
+        ['istanbul', {
+          exclude: [
+            '**',
+            '!**/node_modules/rehabjs/dist/**',
+          ]
+        }]
+      ]
+    }
+  }
 };

--- a/examples/with-react-native/jest.config.js
+++ b/examples/with-react-native/jest.config.js
@@ -1,0 +1,12 @@
+const rehabPath = './node_modules/rehabjs/dist';
+
+module.exports = {
+  preset: "react-native",
+  transformIgnorePatterns: [],
+  collectCoverage: true,
+  collectCoverageFrom: [rehabPath],
+  coverageDirectory: '../../coverage/with-react-native',
+  coverageReporters: [
+    ["lcov", { projectRoot: rehabPath }],
+  ],
+};

--- a/examples/with-react-native/package.json
+++ b/examples/with-react-native/package.json
@@ -19,15 +19,11 @@
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
     "@react-native-community/eslint-config": "^1.1.0",
-    "babel-jest": "^25.1.0",
+    "babel-jest": "^26.0.0",
     "eslint": "^6.5.1",
-    "jest": "^25.5.4",
+    "jest": "^26.0.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-test-renderer": "16.13.1",
     "rehabjs": "file:./rehabjs.tgz"
-  },
-  "jest": {
-    "preset": "react-native",
-    "transformIgnorePatterns": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime": "^7.10.2",
     "@testing-library/react-hooks": "^3.3.0",
-    "jest-diff": "25.4.0",
+    "jest-diff": "^26.0.0",
     "react-component-driver": "^0.10.0",
     "react-test-renderer": "^16.13.1",
     "react-test-renderer-utils": "^2.1.0"
   },
   "peerDependencies": {
-    "jest": "25.4.0",
+    "jest": "^26.0.0",
     "react-native-navigation": "*",
     "lodash": "*",
     "react": "^16.13.1"
@@ -28,8 +29,8 @@
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.2",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.10.4",
-    "@babel/runtime": "^7.10.2",
     "prettier": "2.0.5",
     "semver": "^7.3.2",
     "shell-utils": "^1.0.10"


### PR DESCRIPTION
### Description

Creates `coverage/with-react-native` folder with LCOV and HTML report.
Assumes further integration with Coveralls or a similar service.

### Notes

1. Enforces `package-lock=false` to prevent `npm install` caching related to `rehabjs.tgz` installation trick. Otherwise, after updating dependencies and a consequent `npm install` I see still an old version in `node_modules/rehabjs`, or I get errors [like this](https://npm.community/t/unhandled-rejection-error-invalid-config-key-requested/3957).

```
Unhandled rejection Error: invalid config key requested: errorl
```

2. Makes sure there are no redundant files in `rehabjs.tgz` (the output of `npm pack`) - see the edited `.npmignore`.
3. Makes Babel target `Node 10` and above. Less polyfills - easier to glance at `node_modules/rehabjs/dist` contents in the example project.
4. Enables `@babel/plugin-transform-runtime` to prevent inlining every time long-single-line functions-helpers for Babel like `_defineProperty`, `_defineClass`, etc.
5. Moves Jest config from `package.json` to a separate `jest.config.js` in the example project.
6. Updates Jest to 26.x.
 