### PR TITLE
code: remove unobvious find

### DIFF
--- a/src/component-locator.js
+++ b/src/component-locator.js
@@ -117,7 +117,6 @@ export function componentLocator(driver, findComponents) {
     }
   };
   const methods = {
-    find: ({components}) => (selector = 0) => final(select(components, selector)),
     press: ({components, testID}) => (selector = 0) =>
       fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onPress'})),
     click: ({components, testID}) => (selector = 0) =>


### PR DESCRIPTION
Per our voice chat with @smokiyeno-wix, this `find` method looks like an outlier and behaves very differently from its siblings &mdash; it returns the rendered element itself instead of interacting with it.

If this is fine, let's remove it for now.
