### PR TITLE
code: remove unused press/longPress

### DIFF
--- a/src/component-locator.js
+++ b/src/component-locator.js
@@ -118,14 +118,10 @@ export function componentLocator(driver, findComponents) {
   };
   const methods = {
     find: ({components}) => (selector = 0) => final(select(components, selector)),
-    press: ({components, testID}) => (selector = 0) =>
-      fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onPress'})),
     click: ({components, testID}) => (selector = 0) =>
       fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onClick'})),
     play: ({components, testID}) => (selector = 0) =>
       fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onPlayPress'})),
-    longPress: ({components, testID}) => (selector = 0) =>
-      fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onLongPress'})),
     enter: ({components, testID}) => (text) => fluent(assertFound(components, testID), enterInputText(components[0], text)),
     enterRC: ({components, testID}) => (isEmpty) => fluent(assertFound(components, testID), enterRCContent(components[0], isEmpty)),
     focus: ({components, testID}) => () => fluent(assertFound(components, testID), focus(components[0])),


### PR DESCRIPTION
The problem with these methods is that when you work with vanilla React Native components such as `Button`, `TouchableOpacity`, `Pressable`, etc. is that they don't work. :man_shrugging: 

For example, `<Button testID="myButton" onPress={...}>` on the bottom-most level is transformed to `<View testID="myButton" onClick={...}>`. Hence, when we try to `press` - we fail because there is no prop named `onPress`.

I was not able to find a situation where it will work out-of-the-box with vanilla React Native, so shall we remove it, and leave `click()` only, for now?