### PR TITLE
code: remove unused play

### DIFF
--- a/src/component-locator.js
+++ b/src/component-locator.js
@@ -122,8 +122,6 @@ export function componentLocator(driver, findComponents) {
       fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onPress'})),
     click: ({components, testID}) => (selector = 0) =>
       fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onClick'})),
-    play: ({components, testID}) => (selector = 0) =>
-      fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onPlayPress'})),
     longPress: ({components, testID}) => (selector = 0) =>
       fluent(assertFound(components, testID), simulateComponentEvent(select(components, selector), {event: 'onLongPress'})),
     enter: ({components, testID}) => (text) => fluent(assertFound(components, testID), enterInputText(components[0], text)),


### PR DESCRIPTION
According to Google search results, there is no single React Native component that ships with a built-in `onPlayPress` property.
This is why I suggest removing the corresponding method from the core files.
![Screenshot from 2020-08-08 16-06-18](https://user-images.githubusercontent.com/1962469/89711211-77b41f80-d991-11ea-9d7d-9ae5d269ad7a.png)
